### PR TITLE
Add workflows to GTMS-5

### DIFF
--- a/standards/GTMS-5.md
+++ b/standards/GTMS-5.md
@@ -7,32 +7,47 @@
 There are no standards for the structure of the repository.
 Because of this, the repository's structure is different for each project.
 
-There is no requirement to store the code of a template in a separate file, however, it is hard to read the code of the template if it is not extracted to a separate file.
+There is no requirement to store the code of a template in a separate file, however, it is hard to read the code of the `template.tpl` if it is not extracted to a separate file. This standard requires the template code to be stored in a separate file (`template.js`), which makes it easier to read and maintain.
+
+It also requires the repository to contain a `README.md` file, which is used to describe the template and provide instructions on how to use it. And a `.prettierrc` file, which is used to maintain a consistent code style across the repository.
+
+And finally, it requires the repository to contain the workflow files (in `.github/workflows`) referencing the [shared workflows repository](https://github.com/stape-io/template-changes-shared-workflows/tree/main), which is used to notify template and README changes to Stape Community and perform GTM Gallery Status checks.
+
+Optionally, the repository can contain a `tests.yaml` file (if any tests exist), which is used to store the tests of the template in a separate file.
 
 ### Standard description
 
-Required by GTM Template Gallery:
+#### Required by GTM Template Gallery
+- `LICENSE`
+- `metadata.yaml`
+- `template.tpl`
 
-- LICENSE
-- metadata.yaml
-- template.tpl
+#### Required by this standard
+- `template.js` - template code formatted with [GTMS-4 standard](standards/GTMS-4.md)
+- `README.md` - template description
+- `.prettierrc` - Prettier repo-level configuration
+  ```json
+  {
+    "singleQuote": true,
+    "trailingComma": "none",
+    "tabWidth": 2,
+    "printWidth": 100
+  }
+  ```
+- `tests.yaml` - tests used in the template
+- `.github/workflows/discourse-notify-and-readme-sync.yml` - workflow for template changes notifications to Stape Community and README updates. [Workflow reference](https://github.com/stape-io/template-changes-shared-workflows/tree/main/gtm-templates-specific-workflows/.github/workflows).
+- `.github/workflows/gallery-status.yml` - workflow for GTM Gallery Status checks twice a week. [Workflow reference](https://github.com/stape-io/template-changes-shared-workflows/tree/main/gtm-templates-specific-workflows/.github/workflows).
 
-Required by this standard:
-
-- template.js - Template code
-- .prettierrc - Prettier repo-level configuration
-- tests.yaml - Tests used in the template
-- README.md - Template description
-
-### Tests File
+##### `tests.yaml` File
 
 The tests inside `template.tpl` are written in .yaml syntax. Given that, the file `tests.yaml` must be a copy of what is in the `template.tpl` under `__TESTS__`.
-Observation: When exporting a template, the tests codes are formatted by GTM into an inline compact hard way to read. Before pushing the `tests.yaml` file, make sure the tests codes are formatted properly using yaml code block sintax (`|-`). See illustration below:
+
+Observation: when exporting a template, the tests codes are formatted by GTM into an inline compact hard way to read. Before pushing the `tests.yaml` file, make sure the tests codes are formatted properly using yaml code block sintax (`|-`). See illustration below:
 
 **Correct Format**
 
-![Correct Way](../images/gtms-5-correct.png)
+<img src="../images/gtms-5-correct.png" width="50%" alt="Correct Format"/>
 
 **Wrong Format**
 
-![Wrong Way](../images/gtms-5-wrong.png)
+<img src="../images/gtms-5-wrong.png" width="40%" alt="Wrong Format"/>


### PR DESCRIPTION
This pull request updates the `GTMS-5` repository structure standard to clarify and expand the requirements for template repositories. The changes improve readability, add new required files, and provide more explicit instructions for maintaining consistency and workflow automation.

**Repository structure and required files:**

* The standard now requires the template code to be stored in a separate `template.js` file (previously only recommended), making it easier to read and maintain.
* Added requirements for a `README.md` file (template description), a `.prettierrc` file (consistent code style), and workflow files in `.github/workflows` for notifications and GTM Gallery status checks.
* Clarified that a `tests.yaml` file is optional, used to store template tests separately if they exist.

**Standard description and formatting guidance:**

* Reorganized and clarified the list of required files, grouping them by those required by the GTM Template Gallery and by this standard, and included a sample `.prettierrc` configuration.
* Improved guidance on formatting the `tests.yaml` file, including updated illustrations and formatting recommendations.